### PR TITLE
Generate food count table without ontology levels

### DIFF
--- a/file_food_count-universal-noLevels.ipynb
+++ b/file_food_count-universal-noLevels.ipynb
@@ -1,0 +1,182 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### GFOP sample type metadata "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "gfop_metadata = pd.read_csv(\n",
+    "    '~/Google_Drive/FoodOmics_Data/11442_foodomics_multiproject_metadata.txt', sep='\\t')\n",
+    "# First row is empty.\n",
+    "gfop_metadata = gfop_metadata.drop(index=0)\n",
+    "# Remove trailing whitespace.\n",
+    "gfop_metadata = gfop_metadata.apply(lambda col: col.str.strip()\n",
+    "                                    if col.dtype == 'object' else col)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Food count per file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "def get_file_food_counts(gnps_network, sample_types, all_groups, some_groups,\n",
+    "                         filenames_included):\n",
+    "    # Select GNPS job groups.\n",
+    "    groups = {f'G{i}' for i in range(1, 7)}\n",
+    "    groups_excluded = groups - set([*all_groups, *some_groups])\n",
+    "    df_selected = gnps_network[\n",
+    "        (gnps_network[all_groups] > 0).all(axis=1) &\n",
+    "        (gnps_network[some_groups] > 0).any(axis=1) &\n",
+    "        (gnps_network[groups_excluded] == 0).all(axis=1)].copy()\n",
+    "    df_selected = df_selected[\n",
+    "        df_selected['UniqueFileSources'].apply(lambda cluster_fn:\n",
+    "            any(fn in cluster_fn for fn in filenames_included))]\n",
+    "    filenames = (df_selected['UniqueFileSources'].str.split('|')\n",
+    "                 .explode())\n",
+    "    # Select food sample names (values match terminal leaves of ontology).\n",
+    "    sample_types = sample_types['sample_name']\n",
+    "    # Match the GNPS job results to the food sample types.\n",
+    "    sample_types_selected = sample_types.reindex(filenames)\n",
+    "    sample_types_selected = sample_types_selected.dropna()\n",
+    "    # Discard samples that occur less frequent than water (blank).\n",
+    "    #water_count = sample_types_selected.isin(['11442.G74065','11442.G74067','11442.G74122','11442.G83366','G96583','G96584','G96585','G96586','G96611','G96612','G96613','G96618','G96619','G96639','G96684','G96713']).sum()\n",
+    "    # leave this out for now.. water_count is too high compared to range of sample_counts - need to think of how to filter out noise\n",
+    "    ## first remove any molecules found in water?\n",
+    "    water_count = 0\n",
+    "    sample_counts = sample_types_selected.value_counts()\n",
+    "    sample_counts_valid = sample_counts.index[sample_counts > water_count]\n",
+    "    sample_types_selected = sample_types_selected[\n",
+    "        sample_types_selected.isin(sample_counts_valid)]\n",
+    "    # Get sample counts\n",
+    "    return sample_types_selected.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "sample_types = gfop_metadata.set_index('filename')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "metadata = pd.read_csv(\n",
+    "    '~/Google_Drive/FoodOmics_Data/IBD/IBD200_revamped_metadata_20200707_KAW.txt', sep='\\t')\n",
+    "filename_col = 'Metabolomics.FileName.Run1' # column header for file names"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "gnps_network = pd.read_csv(\n",
+    "    '~/Google_Drive/FoodOmics_Data/IBD/IBD_2-view_all_clusters_withID_beta-main.tsv',\n",
+    "    sep='\\t')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "food_counts, filenames = [], []\n",
+    "    \n",
+    "#Explicit selection of categories.\n",
+    "some_groups = ['G4']\n",
+    "all_groups = ['G1']\n",
+    "for filename in metadata[filename_col]:\n",
+    "    file_food_counts = get_file_food_counts(\n",
+    "        gnps_network, sample_types_simple, all_groups, some_groups, [filename])\n",
+    "    if len(file_food_counts) > 0:\n",
+    "        food_counts.append(file_food_counts)\n",
+    "        filenames.append(filename)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "food_counts = (pd.concat(food_counts, axis=1, sort=True)\n",
+    "               .fillna(0).astype(int).T)\n",
+    "food_counts.index = pd.Index(filenames, name='filename')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "food_counts.to_csv('IBD_2_file_food_count.csv')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Currently does not include filtering out noise by using counts of `water`. Will add similar functionality in future PR, after discussions about how best to proceed.